### PR TITLE
Fix `use parentheses to remove the ambiguity or change the variable

### DIFF
--- a/lib/stripe_eventex.ex
+++ b/lib/stripe_eventex.ex
@@ -43,7 +43,7 @@ defmodule StripeEventex do
 
   defp proccess_event(conn) do
     body = conn |> parse_body
-    case retrieve_event(events, body) do
+    case retrieve_event(events(), body) do
       {_, module} -> subscribed_event(conn, module, body)
       nil -> unknown_event(conn)
       _ -> raise ArgumentError

--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule StripeEventex.Mixfile do
     [app: :stripe_eventex,
      version: "2.0.0",
      elixir: "~> 1.4",
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   def application do

--- a/test/stripe_eventex_test.exs
+++ b/test/stripe_eventex_test.exs
@@ -9,13 +9,13 @@ defmodule StripeEventexTest do
   use Plug.Test
 
   defmodule TrueStripeValidation do
-    def valid!(conn) do
+    def valid!(_conn) do
       true
     end
   end
 
   defmodule FalseStripeValidation do
-    def valid!(conn) do
+    def valid!(_conn) do
       false
     end
   end


### PR DESCRIPTION
name` compile warning